### PR TITLE
Remove `item_id` parameter from item constructor

### DIFF
--- a/src/e4stypes/book_item.py
+++ b/src/e4stypes/book_item.py
@@ -13,10 +13,10 @@ book_col = db.book
 
 
 class BookItem(Item):
-    def __init__(self, item_id: str, title: str, desc: str, price: Decimal,
-                 weight: float, seller: str, book_title: str, edition: int,
+    def __init__(self, title: str, desc: str, price: Decimal, weight: float,
+                 seller: str, book_title: str, edition: int,
                  course_number: int):
-        super().__init__(item_id, title, desc, price, weight, seller)
+        super().__init__(title, desc, price, weight, seller)
 
         # Private instance attributes
         self._book_title: str = book_title

--- a/src/e4stypes/clothing_item.py
+++ b/src/e4stypes/clothing_item.py
@@ -28,10 +28,10 @@ class ClothingSize(Enum):
 
 
 class ClothingItem(Item):
-    def __init__(self, item_id: str, title: str, desc: str, price: Decimal,
-                 weight: float, seller: str, garment_type: str,
-                 size: ClothingSize, gender: ClothingGender, color: str):
-        super().__init__(item_id, title, desc, price, weight, seller)
+    def __init__(self, title: str, desc: str, price: Decimal, weight: float,
+                 seller: str, garment_type: str, size: ClothingSize,
+                 gender: ClothingGender, color: str):
+        super().__init__(title, desc, price, weight, seller)
         self._garment_type = garment_type
         self._size = size
         self._gender = gender

--- a/src/e4stypes/database.py
+++ b/src/e4stypes/database.py
@@ -42,42 +42,49 @@ class Database:
 
         # Returns the Item if a item was found with the given item_id
         if get_clothing:
-            return ClothingItem(get_clothing["_id"], get_clothing["title"],
-                                get_clothing["desc"],
+            item = ClothingItem(get_clothing["title"], get_clothing["desc"],
                                 Decimal(get_clothing["price"]),
                                 get_clothing["weight"], get_clothing["seller"],
                                 get_clothing["garment_type"],
                                 ClothingSize(get_clothing["size"]),
                                 ClothingGender(get_clothing["gender"]),
                                 get_clothing["color"])
+            item.set_item_id(get_clothing["_id"])
+            return item
         if get_book:
-            return BookItem(get_book["_id"],
-                            get_book["title"], get_book["desc"],
+            item = BookItem(get_book["title"], get_book["desc"],
                             Decimal(get_book["price"]), get_book["weight"],
                             get_book["seller"], get_book["book_title"],
                             get_book["edition"], get_book["course_number"])
+            item.set_item_id(get_book["_id"])
+            return item
         if get_furniture:
-            return FurnitureItem(
-                get_furniture["_id"],
-                get_furniture["title"], get_furniture["desc"],
-                Decimal(get_furniture["price"]), get_furniture["weight"],
-                get_furniture["seller"], get_furniture["furnishing_type"],
-                get_furniture["color"], get_furniture["dimensions"])
+            item = FurnitureItem(get_furniture["title"], get_furniture["desc"],
+                                 Decimal(get_furniture["price"]),
+                                 get_furniture["weight"],
+                                 get_furniture["seller"],
+                                 get_furniture["furnishing_type"],
+                                 get_furniture["color"],
+                                 get_furniture["dimensions"])
+            item.set_item_id(get_furniture["_id"])
+            return item
         if get_electronic:
-            return ElectronicItem(
-                get_electronic["_id"],
+            item = ElectronicItem(
                 get_electronic["title"], get_electronic["desc"],
                 Decimal(get_electronic["price"]), get_electronic["weight"],
                 get_electronic["seller"], get_electronic["electronic_type"],
                 get_electronic["model"], get_electronic["dimensions"])
+            item.set_item_id(get_electronic["_id"])
+            return item
         if get_sports:
-            return SportsGearItem(get_sports["_id"], get_sports["title"],
-                                  get_sports["desc"],
+            item = SportsGearItem(get_sports["title"], get_sports["desc"],
                                   Decimal(get_sports["price"]),
                                   get_sports["weight"], get_sports["seller"],
                                   get_sports["gear_type"],
                                   ClothingSize(get_sports["size"]),
                                   ClothingGender(get_sports["gender"]))
+            item.set_item_id(get_sports["_id"])
+            return item
         raise RuntimeError(
             "get_item_by_id: could not find item with passed id")
 
@@ -93,57 +100,59 @@ class Database:
                 # instantiate a ClothingItem based on the
                 # fields of the item dict and then append
                 # it to the running array
-                items.append(
-                    ClothingItem(item_dict["_id"],
-                                 item_dict["title"], item_dict["desc"],
-                                 Decimal(item_dict["price"]),
-                                 item_dict["weight"], item_dict["seller"],
-                                 item_dict["garment_type"],
-                                 ClothingSize(item_dict["size"]),
-                                 ClothingGender(item_dict["gender"]),
-                                 item_dict["color"]))
+                item = ClothingItem(item_dict["title"], item_dict["desc"],
+                                    Decimal(item_dict["price"]),
+                                    item_dict["weight"], item_dict["seller"],
+                                    item_dict["garment_type"],
+                                    ClothingSize(item_dict["size"]),
+                                    ClothingGender(item_dict["gender"]),
+                                    item_dict["color"])
+                item.set_item_id(item_dict["_id"])
+                items.append(item)
             return items
         elif category == 'Book':
             item_dicts = book_col.find({})
             for item_dict in item_dicts:
-                items.append(
-                    BookItem(item_dict["_id"],
-                             item_dict["title"], item_dict["desc"],
-                             Decimal(item_dict["price"]), item_dict["weight"],
-                             item_dict["seller"], item_dict["book_title"],
-                             item_dict["edition"], item_dict["course_number"]))
+                item = BookItem(item_dict["title"], item_dict["desc"],
+                                Decimal(item_dict["price"]),
+                                item_dict["weight"], item_dict["seller"],
+                                item_dict["book_title"], item_dict["edition"],
+                                item_dict["course_number"])
+                item.set_item_id(item_dict["_id"])
+                items.append(item)
         elif category == 'Furniture':
             item_dicts = furniture_col.find({})
             for item_dict in item_dicts:
-                items.append(
-                    FurnitureItem(item_dict["_id"],
-                                  item_dict["title"], item_dict["desc"],
-                                  Decimal(item_dict["price"]),
-                                  item_dict["weight"], item_dict["seller"],
-                                  item_dict["furnishing_type"],
-                                  item_dict["color"], item_dict["dimensions"]))
+                item = FurnitureItem(item_dict["title"], item_dict["desc"],
+                                     Decimal(item_dict["price"]),
+                                     item_dict["weight"], item_dict["seller"],
+                                     item_dict["furnishing_type"],
+                                     item_dict["color"],
+                                     item_dict["dimensions"])
+                item.set_item_id(item_dict["_id"])
+                items.append(item)
         elif category == 'Electronic':
             item_dicts = electronic_col.find({})
             for item_dict in item_dicts:
-                items.append(
-                    ElectronicItem(item_dict["_id"], item_dict["title"],
-                                   item_dict["desc"],
-                                   Decimal(item_dict["price"]),
-                                   item_dict["weight"], item_dict["seller"],
-                                   item_dict["electronic_type"],
-                                   item_dict["model"],
-                                   item_dict["dimensions"]))
+                item = ElectronicItem(item_dict["title"], item_dict["desc"],
+                                      Decimal(item_dict["price"]),
+                                      item_dict["weight"], item_dict["seller"],
+                                      item_dict["electronic_type"],
+                                      item_dict["model"],
+                                      item_dict["dimensions"])
+                item.set_item_id(item_dict["_id"])
+                items.append(item)
         elif category == 'Sports Gear':
             item_dicts = sports_gear_col.find({})
             for item_dict in item_dicts:
-                items.append(
-                    SportsGearItem(item_dict["_id"], item_dict["title"],
-                                   item_dict["desc"],
-                                   Decimal(item_dict["price"]),
-                                   item_dict["weight"], item_dict["seller"],
-                                   item_dict["gear_type"],
-                                   ClothingSize(item_dict["size"]),
-                                   ClothingGender(item_dict["gender"])))
+                item = SportsGearItem(item_dict["title"], item_dict["desc"],
+                                      Decimal(item_dict["price"]),
+                                      item_dict["weight"], item_dict["seller"],
+                                      item_dict["gear_type"],
+                                      ClothingSize(item_dict["size"]),
+                                      ClothingGender(item_dict["gender"]))
+                item.set_item_id(item_dict["_id"])
+                items.append(item)
         else:
             raise RuntimeError("get_item_by_category: category undefined")
         return items

--- a/src/e4stypes/electronic_item.py
+++ b/src/e4stypes/electronic_item.py
@@ -14,10 +14,10 @@ electronic_col = db.electronic
 
 
 class ElectronicItem(Item):
-    def __init__(self, item_id: str, title: str, desc: str, price: Decimal,
-                 weight: float, seller: str, electronic_type: str, model: str,
+    def __init__(self, title: str, desc: str, price: Decimal, weight: float,
+                 seller: str, electronic_type: str, model: str,
                  dimensions: List[int]):
-        super().__init__(item_id, title, desc, price, weight, seller)
+        super().__init__(title, desc, price, weight, seller)
 
         # Private instance attributes
         self._electronic_type: str = electronic_type

--- a/src/e4stypes/furniture_item.py
+++ b/src/e4stypes/furniture_item.py
@@ -15,10 +15,10 @@ furniture_col = db.furniture
 
 
 class FurnitureItem(Item):
-    def __init__(self, item_id: str, title: str, desc: str, price: Decimal,
-                 weight: float, seller: str, furnishing_type: str, color: str,
+    def __init__(self, title: str, desc: str, price: Decimal, weight: float,
+                 seller: str, furnishing_type: str, color: str,
                  dimensions: List[int]):
-        super().__init__(item_id, title, desc, price, weight, seller)
+        super().__init__(title, desc, price, weight, seller)
 
         # Private instance attributes
         self._furnishing_type: str = furnishing_type

--- a/src/e4stypes/item.py
+++ b/src/e4stypes/item.py
@@ -22,6 +22,9 @@ class Item:
     def get_item_id(self) -> str:
         return self._item_id
 
+    def set_item_id(self, item_id: str) -> type(None):
+        self._item_id = item_id
+
     def get_title(self) -> str:
         return self._title
 

--- a/src/e4stypes/item.py
+++ b/src/e4stypes/item.py
@@ -5,10 +5,10 @@ class Item:
     """
     An item listed by a user on the site.
     """
-    def __init__(self, item_id: str, title: str, desc: str, price: Decimal,
-                 weight: float, seller: str):
+    def __init__(self, title: str, desc: str, price: Decimal, weight: float,
+                 seller: str):
         # Private instance attributes
-        self._item_id: str = item_id
+        self._item_id: str = ""
         self._title: str = title
         self._description: str = desc
         self._price: Decimal = price

--- a/src/e4stypes/sports_gear_item.py
+++ b/src/e4stypes/sports_gear_item.py
@@ -16,10 +16,10 @@ sports_gear_col = db.sports_gear
 
 
 class SportsGearItem(Item):
-    def __init__(self, item_id: str, title: str, desc: str, price: Decimal,
-                 weight: float, seller: str, gear_type: str,
-                 size: ClothingSize, gender: ClothingGender):
-        super().__init__(item_id, title, desc, price, weight, seller)
+    def __init__(self, title: str, desc: str, price: Decimal, weight: float,
+                 seller: str, gear_type: str, size: ClothingSize,
+                 gender: ClothingGender):
+        super().__init__(title, desc, price, weight, seller)
 
         # Private instance attributes
         self._gear_type: str = gear_type


### PR DESCRIPTION
Because the id of an object is not known until it is retrieved from the database, it does not make sense to have that be a parameter of the constructor. This way, after the user fills out the form, the Item object can be created based on the user's input and then posted to the database.
