### PR TITLE
Downgraded werkzeug

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ Flask-Login
 Flask-WTF
 pymongo
 flask_uploads
+werkzeug==0.16.0


### PR DESCRIPTION
Looks like the most recent version of the werkzeug package is bugged. We'll need to use version 0.16.0 instead of the most recent version.