### PR TITLE
Change formatter from yapf to black

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,11 +13,11 @@ jobs:
         steps:
             - uses: actions/checkout@v2
              
-            - name: Install yapf
-              run: pip3 install yapf
+            - name: Install black
+              run: pip3 install black
             
             - name: Enforce formatting with yapf
-              run: test -z $(python3 -m yapf -rd . | tr -d "\n\t ")
+              run: python3 -m black --check
 
             - name: Install pylint
               run: pip3 install pylint

--- a/src/app.py
+++ b/src/app.py
@@ -12,78 +12,79 @@ basedir = os.path.abspath(os.path.dirname(__file__))
 
 app = Flask(__name__)
 
-app.config['SECRET_KEY'] = 'Howdy D6'
-if not os.path.exists(os.path.join(basedir, 'uploads')):
-    os.mkdir(os.path.join(basedir, 'uploads'))
-app.config['UPLOADED_PHOTOS_DEST'] = os.path.join(basedir, 'uploads')
+app.config["SECRET_KEY"] = "Howdy D6"
+if not os.path.exists(os.path.join(basedir, "uploads")):
+    os.mkdir(os.path.join(basedir, "uploads"))
+app.config["UPLOADED_PHOTOS_DEST"] = os.path.join(basedir, "uploads")
 
 
-@app.route('/')
+@app.route("/")
 def get_home():
-    return render_template('/home.html', items=Database.get_all())
+    return render_template("/home.html", items=Database.get_all())
 
 
-@app.route('/books')
+@app.route("/books")
 def get_books():
-    return render_template('/books.html',
-                           items=Database.get_item_by_category(Category.BOOK))
+    return render_template(
+        "/books.html", items=Database.get_item_by_category(Category.BOOK)
+    )
 
 
-@app.route('/clothes')
+@app.route("/clothes")
 def get_clothes():
-    return render_template('/clothes.html',
-                           items=Database.get_item_by_category(
-                               Category.CLOTHING))
+    return render_template(
+        "/clothes.html", items=Database.get_item_by_category(Category.CLOTHING)
+    )
 
 
-@app.route('/electronics')
+@app.route("/electronics")
 def get_electronics():
-    return render_template('/electronics.html',
-                           items=Database.get_item_by_category(
-                               Category.ELECTRONIC))
+    return render_template(
+        "/electronics.html", items=Database.get_item_by_category(Category.ELECTRONIC)
+    )
 
 
-@app.route('/sports')
+@app.route("/sports")
 def get_sports():
-    return render_template('/sports.html',
-                           items=Database.get_item_by_category(
-                               Category.SPORTS_GEAR))
+    return render_template(
+        "/sports.html", items=Database.get_item_by_category(Category.SPORTS_GEAR)
+    )
 
 
-@app.route('/furniture')
+@app.route("/furniture")
 def get_furniture():
-    return render_template('/furniture.html',
-                           items=Database.get_item_by_category(
-                               Category.FURNITURE))
+    return render_template(
+        "/furniture.html", items=Database.get_item_by_category(Category.FURNITURE)
+    )
 
 
-@app.route('/sell', methods=['GET', 'POST'])
+@app.route("/sell", methods=["GET", "POST"])
 def get_sell():
-    if request.method == 'POST':
-        #grab form data in order they appear in sell.html
-        category = request.form['category_drop_val']
-        post_title = request.form['post_title_val']
-        price = request.form['price_val']
-        title = request.form['title_val']
-        edition = request.form['ed_val']
-        if request.form['length_val'] != "":
+    if request.method == "POST":
+        # grab form data in order they appear in sell.html
+        category = request.form["category_drop_val"]
+        post_title = request.form["post_title_val"]
+        price = request.form["price_val"]
+        title = request.form["title_val"]
+        edition = request.form["ed_val"]
+        if request.form["length_val"] != "":
             dimensions = [
-                int(request.form['length_val']),
-                int(request.form['width_val']),
-                int(request.form['height_val'])
+                int(request.form["length_val"]),
+                int(request.form["width_val"]),
+                int(request.form["height_val"]),
             ]
-        weight = request.form['weight_val']
-        color = request.form['color_val']
-        #type is a key word
-        type_val = request.form['type_val']
-        course_num = request.form['course_num_val']
-        size = request.form['size_val']
-        gender = request.form['gender_val']
-        model = request.form['model_val']
-        description = request.form['comments_val']
-        seller = request.form['seller_val']
+        weight = request.form["weight_val"]
+        color = request.form["color_val"]
+        # type is a key word
+        type_val = request.form["type_val"]
+        course_num = request.form["course_num_val"]
+        size = request.form["size_val"]
+        gender = request.form["gender_val"]
+        model = request.form["model_val"]
+        description = request.form["comments_val"]
+        seller = request.form["seller_val"]
 
-        #photo upload
+        # photo upload
         # file = request.files['file']
         # f_name = file.filename
         # file.save(os.path.join(app.config['UPLOADED_PHOTOS_DEST'], f_name))
@@ -91,93 +92,131 @@ def get_sell():
         # file_path = "../uploads/" + f_name
 
         # create item and add item to database
-        if category == 'books':
-            item = BookItem(post_title, description, Decimal(price.strip()),
-                            float(weight.strip()), seller, title, edition,
-                            course_num)
+        if category == "books":
+            item = BookItem(
+                post_title,
+                description,
+                Decimal(price.strip()),
+                float(weight.strip()),
+                seller,
+                title,
+                edition,
+                course_num,
+            )
             Database.add_item(item)
-        elif category == 'furniture':
-            item = FurnitureItem(post_title,
-                                 description, Decimal(price.strip()),
-                                 float(weight.strip()), seller, type_val,
-                                 color, dimensions)
+        elif category == "furniture":
+            item = FurnitureItem(
+                post_title,
+                description,
+                Decimal(price.strip()),
+                float(weight.strip()),
+                seller,
+                type_val,
+                color,
+                dimensions,
+            )
             Database.add_item(item)
-        elif category == 'clothes':
-            item = ClothingItem(post_title,
-                                description, Decimal(price.strip()),
-                                float(weight.strip()), seller, type_val,
-                                int(size), int(gender), color)
+        elif category == "clothes":
+            item = ClothingItem(
+                post_title,
+                description,
+                Decimal(price.strip()),
+                float(weight.strip()),
+                seller,
+                type_val,
+                int(size),
+                int(gender),
+                color,
+            )
             Database.add_item(item)
-        elif category == 'sports':
+        elif category == "sports":
             Database.add_item(
-                SportsGearItem(post_title, description, Decimal(price.strip()),
-                               float(weight.strip()), seller, type_val,
-                               int(size), int(gender)))
-        elif category == 'electronics':
-            item = ElectronicItem(post_title, description,
-                                  Decimal(price.strip()),
-                                  float(weight.strip()), seller, type_val,
-                                  model, dimensions)
+                SportsGearItem(
+                    post_title,
+                    description,
+                    Decimal(price.strip()),
+                    float(weight.strip()),
+                    seller,
+                    type_val,
+                    int(size),
+                    int(gender),
+                )
+            )
+        elif category == "electronics":
+            item = ElectronicItem(
+                post_title,
+                description,
+                Decimal(price.strip()),
+                float(weight.strip()),
+                seller,
+                type_val,
+                model,
+                dimensions,
+            )
             Database.add_item(item)
-        return render_template('/sell.html')
-    return render_template('/sell.html')
+        return render_template("/sell.html")
+    return render_template("/sell.html")
 
 
-@app.route('/view/<item_id>')
+@app.route("/view/<item_id>")
 def get_view(item_id):
     item = Database.get_item_by_id(item_id)
     if isinstance(item, ClothingItem):
-        return render_template('/view.html',
-                               item=item,
-                               small=item.get_size() == 0,
-                               medium=item.get_size() == 1,
-                               large=item.get_size() == 2,
-                               xlarge=item.get_size() == 3,
-                               unisex=item.get_gender() == 0,
-                               female=item.get_gender() == 1,
-                               male=item.get_gender() == 2,
-                               clothing=True)
+        return render_template(
+            "/view.html",
+            item=item,
+            small=item.get_size() == 0,
+            medium=item.get_size() == 1,
+            large=item.get_size() == 2,
+            xlarge=item.get_size() == 3,
+            unisex=item.get_gender() == 0,
+            female=item.get_gender() == 1,
+            male=item.get_gender() == 2,
+            clothing=True,
+        )
 
     if isinstance(item, BookItem):
-        return render_template('/view.html', item=item, book=True)
+        return render_template("/view.html", item=item, book=True)
 
     if isinstance(item, FurnitureItem):
-        return render_template('/view.html', item=item, furn=True)
+        return render_template("/view.html", item=item, furn=True)
 
     if isinstance(item, ElectronicItem):
-        return render_template('/view.html', item=item, elect=True)
+        return render_template("/view.html", item=item, elect=True)
 
     if isinstance(item, SportsGearItem):
-        return render_template('/view.html',
-                               item=item,
-                               small=item.get_size() == 0,
-                               medium=item.get_size() == 1,
-                               large=item.get_size() == 2,
-                               xlarge=item.get_size() == 3,
-                               unisex=item.get_gender() == 0,
-                               female=item.get_gender() == 1,
-                               male=item.get_gender() == 2,
-                               sports=True)
+        return render_template(
+            "/view.html",
+            item=item,
+            small=item.get_size() == 0,
+            medium=item.get_size() == 1,
+            large=item.get_size() == 2,
+            xlarge=item.get_size() == 3,
+            unisex=item.get_gender() == 0,
+            female=item.get_gender() == 1,
+            male=item.get_gender() == 2,
+            sports=True,
+        )
 
 
 @app.errorhandler(404)
 def page_not_found(error):
     print(error)
-    return render_template('/404.html'), 404
+    return render_template("/404.html"), 404
 
 
 @app.errorhandler(500)
 def internal_server_error(error):
     # will only be triggered when debug mode is off, this is default flask behaivior
     print(error)
-    return render_template('/500.html'), 500
+    return render_template("/500.html"), 500
 
 
-@app.route('/search', methods=['GET', 'POST'])
+@app.route("/search", methods=["GET", "POST"])
 def get_search():
-    if request.method == 'POST':
-        term = request.form['search_term']
-    return render_template('/results.html', items=Database.search_item(term))
+    if request.method == "POST":
+        term = request.form["search_term"]
+    return render_template("/results.html", items=Database.search_item(term))
 
 
 if __name__ == "__main__":

--- a/src/e4stypes/book_item.py
+++ b/src/e4stypes/book_item.py
@@ -4,9 +4,17 @@ from .item import Item
 
 
 class BookItem(Item):
-    def __init__(self, title: str, desc: str, price: Decimal, weight: float,
-                 seller: str, book_title: str, edition: int,
-                 course_number: int):
+    def __init__(
+        self,
+        title: str,
+        desc: str,
+        price: Decimal,
+        weight: float,
+        seller: str,
+        book_title: str,
+        edition: int,
+        course_number: int,
+    ):
         super().__init__(title, desc, price, weight, seller)
 
         # Private instance attributes
@@ -25,13 +33,13 @@ class BookItem(Item):
 
     def to_dict(self) -> Dict:
         return {
-            'title': self.get_title(),
-            'desc': self.get_description(),
-            'price': float(self.get_price()),
-            'weight': self.get_weight(),
-            'seller': self.get_seller(),
+            "title": self.get_title(),
+            "desc": self.get_description(),
+            "price": float(self.get_price()),
+            "weight": self.get_weight(),
+            "seller": self.get_seller(),
             # 'img': self.get_img(),
-            'book_title': self.get_book_title(),
-            'edition': self.get_edition(),
-            'course_number': self.get_course_number()
+            "book_title": self.get_book_title(),
+            "edition": self.get_edition(),
+            "course_number": self.get_course_number(),
         }

--- a/src/e4stypes/clothing_item.py
+++ b/src/e4stypes/clothing_item.py
@@ -19,9 +19,18 @@ class ClothingSize(IntEnum):
 
 
 class ClothingItem(Item):
-    def __init__(self, title: str, desc: str, price: Decimal, weight: float,
-                 seller: str, garment_type: str, size: ClothingSize,
-                 gender: ClothingGender, color: str):
+    def __init__(
+        self,
+        title: str,
+        desc: str,
+        price: Decimal,
+        weight: float,
+        seller: str,
+        garment_type: str,
+        size: ClothingSize,
+        gender: ClothingGender,
+        color: str,
+    ):
         super().__init__(title, desc, price, weight, seller)
         self._garment_type = garment_type
         self._size = size
@@ -42,13 +51,13 @@ class ClothingItem(Item):
 
     def to_dict(self) -> Dict:
         return {
-            'title': self.get_title(),
-            'desc': self.get_description(),
-            'price': float(self.get_price()),
-            'weight': self.get_weight(),
-            'seller': self.get_seller(),
-            'garment_type': self.get_garment_type(),
-            'size': self.get_size(),
-            'gender': self.get_gender(),
-            'color': self.get_color()
+            "title": self.get_title(),
+            "desc": self.get_description(),
+            "price": float(self.get_price()),
+            "weight": self.get_weight(),
+            "seller": self.get_seller(),
+            "garment_type": self.get_garment_type(),
+            "size": self.get_size(),
+            "gender": self.get_gender(),
+            "color": self.get_color(),
         }

--- a/src/e4stypes/customer.py
+++ b/src/e4stypes/customer.py
@@ -11,9 +11,12 @@ class Customer(metaclass=ABCMeta):
     def purchase_item(item_id: int) -> type(None):
 
     """
+
     @classmethod
     def __subclasshook__(cls, subclass):
-        return (hasattr(subclass, 'send_message_to_seller')
-                and callable(subclass.send_message_to_seller)
-                and hasattr(subclass, 'purchase_item')
-                and callable(subclass.purchase_item))
+        return (
+            hasattr(subclass, "send_message_to_seller")
+            and callable(subclass.send_message_to_seller)
+            and hasattr(subclass, "purchase_item")
+            and callable(subclass.purchase_item)
+        )

--- a/src/e4stypes/database.py
+++ b/src/e4stypes/database.py
@@ -11,7 +11,7 @@ from .furniture_item import FurnitureItem
 from .sports_gear_item import SportsGearItem
 
 # establish connection with database
-myclient = pymongo.MongoClient('mongodb://localhost:27017/')
+myclient = pymongo.MongoClient("mongodb://localhost:27017/")
 # create the databse if it doesn't already exist
 db = myclient.exchange4students
 
@@ -34,47 +34,72 @@ class Category(Enum):
 # Helper methods
 
 
-def _first_found_item(clo_query, book_query, furn_query, elec_query,
-                      spo_query) -> Item:
+def _first_found_item(clo_query, book_query, furn_query, elec_query, spo_query) -> Item:
     # Returns the Item if a item was found with the given item_id
     if clo_query:
-        item = ClothingItem(clo_query["title"], clo_query["desc"],
-                            Decimal(clo_query["price"]), clo_query["weight"],
-                            clo_query["seller"], clo_query["garment_type"],
-                            ClothingSize(clo_query["size"]),
-                            ClothingGender(clo_query["gender"]),
-                            clo_query["color"])
+        item = ClothingItem(
+            clo_query["title"],
+            clo_query["desc"],
+            Decimal(clo_query["price"]),
+            clo_query["weight"],
+            clo_query["seller"],
+            clo_query["garment_type"],
+            ClothingSize(clo_query["size"]),
+            ClothingGender(clo_query["gender"]),
+            clo_query["color"],
+        )
         item.set_item_id(clo_query["_id"])
         return item
     if book_query:
-        item = BookItem(book_query["title"], book_query["desc"],
-                        Decimal(book_query["price"]), book_query["weight"],
-                        book_query["seller"], book_query["book_title"],
-                        book_query["edition"], book_query["course_number"])
+        item = BookItem(
+            book_query["title"],
+            book_query["desc"],
+            Decimal(book_query["price"]),
+            book_query["weight"],
+            book_query["seller"],
+            book_query["book_title"],
+            book_query["edition"],
+            book_query["course_number"],
+        )
         item.set_item_id(book_query["_id"])
         return item
     if furn_query:
-        item = FurnitureItem(furn_query["title"], furn_query["desc"],
-                             Decimal(furn_query["price"]),
-                             furn_query["weight"], furn_query["seller"],
-                             furn_query["furnishing_type"],
-                             furn_query["color"], furn_query["dimensions"])
+        item = FurnitureItem(
+            furn_query["title"],
+            furn_query["desc"],
+            Decimal(furn_query["price"]),
+            furn_query["weight"],
+            furn_query["seller"],
+            furn_query["furnishing_type"],
+            furn_query["color"],
+            furn_query["dimensions"],
+        )
         item.set_item_id(furn_query["_id"])
         return item
     if elec_query:
-        item = ElectronicItem(elec_query["title"], elec_query["desc"],
-                              Decimal(elec_query["price"]),
-                              elec_query["weight"], elec_query["seller"],
-                              elec_query["electronic_type"],
-                              elec_query["model"], elec_query["dimensions"])
+        item = ElectronicItem(
+            elec_query["title"],
+            elec_query["desc"],
+            Decimal(elec_query["price"]),
+            elec_query["weight"],
+            elec_query["seller"],
+            elec_query["electronic_type"],
+            elec_query["model"],
+            elec_query["dimensions"],
+        )
         item.set_item_id(elec_query["_id"])
         return item
     if spo_query:
-        item = SportsGearItem(spo_query["title"], spo_query["desc"],
-                              Decimal(spo_query["price"]), spo_query["weight"],
-                              spo_query["seller"], spo_query["gear_type"],
-                              ClothingSize(spo_query["size"]),
-                              ClothingGender(spo_query["gender"]))
+        item = SportsGearItem(
+            spo_query["title"],
+            spo_query["desc"],
+            Decimal(spo_query["price"]),
+            spo_query["weight"],
+            spo_query["seller"],
+            spo_query["gear_type"],
+            ClothingSize(spo_query["size"]),
+            ClothingGender(spo_query["gender"]),
+        )
         item.set_item_id(spo_query["_id"])
         return item
     raise RuntimeError("get_item_by_id: could not find item with passed id")
@@ -87,54 +112,78 @@ def _all_items_from_item_dicts(item_dicts, category):
             # instantiate a ClothingItem based on the
             # fields of the item dict and then append
             # it to the running array
-            item = ClothingItem(item_dict["title"], item_dict["desc"],
-                                Decimal(item_dict["price"]),
-                                item_dict["weight"], item_dict["seller"],
-                                item_dict["garment_type"],
-                                ClothingSize(item_dict["size"]),
-                                ClothingGender(item_dict["gender"]),
-                                item_dict["color"])
+            item = ClothingItem(
+                item_dict["title"],
+                item_dict["desc"],
+                Decimal(item_dict["price"]),
+                item_dict["weight"],
+                item_dict["seller"],
+                item_dict["garment_type"],
+                ClothingSize(item_dict["size"]),
+                ClothingGender(item_dict["gender"]),
+                item_dict["color"],
+            )
             item.set_item_id(item_dict["_id"])
             items.append(item)
         return items
     if category == Category.BOOK:
         for item_dict in item_dicts:
-            item = BookItem(item_dict["title"], item_dict["desc"],
-                            Decimal(item_dict["price"]), item_dict["weight"],
-                            item_dict["seller"], item_dict["book_title"],
-                            item_dict["edition"], item_dict["course_number"])
+            item = BookItem(
+                item_dict["title"],
+                item_dict["desc"],
+                Decimal(item_dict["price"]),
+                item_dict["weight"],
+                item_dict["seller"],
+                item_dict["book_title"],
+                item_dict["edition"],
+                item_dict["course_number"],
+            )
             item.set_item_id(item_dict["_id"])
             items.append(item)
         return items
     if category == Category.FURNITURE:
         item_dicts = furniture_col.find({})
         for item_dict in item_dicts:
-            item = FurnitureItem(item_dict["title"], item_dict["desc"],
-                                 Decimal(item_dict["price"]),
-                                 item_dict["weight"], item_dict["seller"],
-                                 item_dict["furnishing_type"],
-                                 item_dict["color"], item_dict["dimensions"])
+            item = FurnitureItem(
+                item_dict["title"],
+                item_dict["desc"],
+                Decimal(item_dict["price"]),
+                item_dict["weight"],
+                item_dict["seller"],
+                item_dict["furnishing_type"],
+                item_dict["color"],
+                item_dict["dimensions"],
+            )
             item.set_item_id(item_dict["_id"])
             items.append(item)
         return items
     if category == Category.ELECTRONIC:
         for item_dict in item_dicts:
-            item = ElectronicItem(item_dict["title"], item_dict["desc"],
-                                  Decimal(item_dict["price"]),
-                                  item_dict["weight"], item_dict["seller"],
-                                  item_dict["electronic_type"],
-                                  item_dict["model"], item_dict["dimensions"])
+            item = ElectronicItem(
+                item_dict["title"],
+                item_dict["desc"],
+                Decimal(item_dict["price"]),
+                item_dict["weight"],
+                item_dict["seller"],
+                item_dict["electronic_type"],
+                item_dict["model"],
+                item_dict["dimensions"],
+            )
             item.set_item_id(item_dict["_id"])
             items.append(item)
         return items
     if category == Category.SPORTS_GEAR:
         for item_dict in item_dicts:
-            item = SportsGearItem(item_dict["title"], item_dict["desc"],
-                                  Decimal(item_dict["price"]),
-                                  item_dict["weight"], item_dict["seller"],
-                                  item_dict["gear_type"],
-                                  ClothingSize(item_dict["size"]),
-                                  ClothingGender(item_dict["gender"]))
+            item = SportsGearItem(
+                item_dict["title"],
+                item_dict["desc"],
+                Decimal(item_dict["price"]),
+                item_dict["weight"],
+                item_dict["seller"],
+                item_dict["gear_type"],
+                ClothingSize(item_dict["size"]),
+                ClothingGender(item_dict["gender"]),
+            )
             item.set_item_id(item_dict["_id"])
             items.append(item)
         return items
@@ -144,23 +193,26 @@ def _all_items_from_item_dicts(item_dicts, category):
 class Database:
     @classmethod
     def get_all(cls) -> List[Item]:
-        return (Database.get_item_by_category(Category.CLOTHING) +
-                Database.get_item_by_category(Category.BOOK) +
-                Database.get_item_by_category(Category.FURNITURE) +
-                Database.get_item_by_category(Category.ELECTRONIC) +
-                Database.get_item_by_category(Category.SPORTS_GEAR))
+        return (
+            Database.get_item_by_category(Category.CLOTHING)
+            + Database.get_item_by_category(Category.BOOK)
+            + Database.get_item_by_category(Category.FURNITURE)
+            + Database.get_item_by_category(Category.ELECTRONIC)
+            + Database.get_item_by_category(Category.SPORTS_GEAR)
+        )
 
     @classmethod
     def get_item_by_id(cls, item_id: str) -> Item:
         # Stores the result of the search
-        get_clothing = clothing_col.find_one({'_id': ObjectId(item_id)})
-        get_book = book_col.find_one({'_id': ObjectId(item_id)})
-        get_furniture = furniture_col.find_one({'_id': ObjectId(item_id)})
-        get_electronic = electronic_col.find_one({'_id': ObjectId(item_id)})
-        get_sports = sports_gear_col.find_one({'_id': ObjectId(item_id)})
+        get_clothing = clothing_col.find_one({"_id": ObjectId(item_id)})
+        get_book = book_col.find_one({"_id": ObjectId(item_id)})
+        get_furniture = furniture_col.find_one({"_id": ObjectId(item_id)})
+        get_electronic = electronic_col.find_one({"_id": ObjectId(item_id)})
+        get_sports = sports_gear_col.find_one({"_id": ObjectId(item_id)})
 
-        return _first_found_item(get_clothing, get_book, get_furniture,
-                                 get_electronic, get_sports)
+        return _first_found_item(
+            get_clothing, get_book, get_furniture, get_electronic, get_sports
+        )
 
     @classmethod
     def get_item_by_category(cls, category: Category) -> List[Item]:

--- a/src/e4stypes/electronic_item.py
+++ b/src/e4stypes/electronic_item.py
@@ -4,9 +4,17 @@ from .item import Item
 
 
 class ElectronicItem(Item):
-    def __init__(self, title: str, desc: str, price: Decimal, weight: float,
-                 seller: str, electronic_type: str, model: str,
-                 dimensions: List[int]):
+    def __init__(
+        self,
+        title: str,
+        desc: str,
+        price: Decimal,
+        weight: float,
+        seller: str,
+        electronic_type: str,
+        model: str,
+        dimensions: List[int],
+    ):
         super().__init__(title, desc, price, weight, seller)
 
         # Private instance attributes
@@ -25,12 +33,12 @@ class ElectronicItem(Item):
 
     def to_dict(self) -> Dict:
         return {
-            'title': self.get_title(),
-            'desc': self.get_description(),
-            'price': float(self.get_price()),
-            'weight': self.get_weight(),
-            'seller': self.get_seller(),
-            'electronic_type': self.get_electronic_type(),
-            'model': self.get_model(),
-            'dimensions': self.get_dimensions()
+            "title": self.get_title(),
+            "desc": self.get_description(),
+            "price": float(self.get_price()),
+            "weight": self.get_weight(),
+            "seller": self.get_seller(),
+            "electronic_type": self.get_electronic_type(),
+            "model": self.get_model(),
+            "dimensions": self.get_dimensions(),
         }

--- a/src/e4stypes/furniture_item.py
+++ b/src/e4stypes/furniture_item.py
@@ -5,9 +5,17 @@ from .item import Item
 
 
 class FurnitureItem(Item):
-    def __init__(self, title: str, desc: str, price: Decimal, weight: float,
-                 seller: str, furnishing_type: str, color: str,
-                 dimensions: List[int]):
+    def __init__(
+        self,
+        title: str,
+        desc: str,
+        price: Decimal,
+        weight: float,
+        seller: str,
+        furnishing_type: str,
+        color: str,
+        dimensions: List[int],
+    ):
         super().__init__(title, desc, price, weight, seller)
 
         # Private instance attributes
@@ -26,12 +34,12 @@ class FurnitureItem(Item):
 
     def to_dict(self) -> Dict:
         return {
-            'title': self.get_title(),
-            'desc': self.get_description(),
-            'price': float(self.get_price()),
-            'weight': self.get_weight(),
-            'seller': self.get_seller(),
-            'furnishing_type': self.get_furnishing_type(),
-            'color': self.get_color(),
-            'dimensions': self.get_dimensions()
+            "title": self.get_title(),
+            "desc": self.get_description(),
+            "price": float(self.get_price()),
+            "weight": self.get_weight(),
+            "seller": self.get_seller(),
+            "furnishing_type": self.get_furnishing_type(),
+            "color": self.get_color(),
+            "dimensions": self.get_dimensions(),
         }

--- a/src/e4stypes/item.py
+++ b/src/e4stypes/item.py
@@ -5,8 +5,10 @@ class Item:
     """
     An item listed by a user on the site.
     """
-    def __init__(self, title: str, desc: str, price: Decimal, weight: float,
-                 seller: str):
+
+    def __init__(
+        self, title: str, desc: str, price: Decimal, weight: float, seller: str
+    ):
         # Private instance attributes
         self._item_id: str = ""
         self._title: str = title
@@ -15,7 +17,7 @@ class Item:
         self._weight: float = weight
         self._seller: str = seller
         self._condition: str = ""
-        #self._img: str = img
+        # self._img: str = img
 
         # Public instance attributes
         self.quantity: int = 1

--- a/src/e4stypes/seller.py
+++ b/src/e4stypes/seller.py
@@ -11,8 +11,12 @@ class Seller(metaclass=ABCMeta):
     def edit_item(item_id: int) -> None:
 
     """
+
     @classmethod
     def __subclasshook__(cls, subclass):
-        return (hasattr(subclass, 'post_item') and callable(subclass.post_item)
-                and hasattr(subclass, 'edit_item')
-                and callable(subclass.edit_item))
+        return (
+            hasattr(subclass, "post_item")
+            and callable(subclass.post_item)
+            and hasattr(subclass, "edit_item")
+            and callable(subclass.edit_item)
+        )

--- a/src/e4stypes/sports_gear_item.py
+++ b/src/e4stypes/sports_gear_item.py
@@ -6,9 +6,17 @@ from .clothing_item import ClothingGender, ClothingSize
 
 
 class SportsGearItem(Item):
-    def __init__(self, title: str, desc: str, price: Decimal, weight: float,
-                 seller: str, gear_type: str, size: ClothingSize,
-                 gender: ClothingGender):
+    def __init__(
+        self,
+        title: str,
+        desc: str,
+        price: Decimal,
+        weight: float,
+        seller: str,
+        gear_type: str,
+        size: ClothingSize,
+        gender: ClothingGender,
+    ):
         super().__init__(title, desc, price, weight, seller)
 
         # Private instance attributes
@@ -27,12 +35,12 @@ class SportsGearItem(Item):
 
     def to_dict(self) -> Dict:
         return {
-            'title': self.get_title(),
-            'desc': self.get_description(),
-            'price': float(self.get_price()),
-            'weight': self.get_weight(),
-            'seller': self.get_seller(),
-            'gear_type': self.get_gear_type(),
-            'size': self.get_size(),
-            'gender': self.get_gender()
+            "title": self.get_title(),
+            "desc": self.get_description(),
+            "price": float(self.get_price()),
+            "weight": self.get_weight(),
+            "seller": self.get_seller(),
+            "gear_type": self.get_gear_type(),
+            "size": self.get_size(),
+            "gender": self.get_gender(),
         }

--- a/src/e4stypes/user.py
+++ b/src/e4stypes/user.py
@@ -5,8 +5,9 @@ Contains a User class.
 
 class User:
     """
-    Represents a user of the website. 
+    Represents a user of the website.
     """
+
     def __init__(self, display_name: str, email: str, password: str):
         # Private instance attributes
         self._display_name = display_name

--- a/src/seed.py
+++ b/src/seed.py
@@ -5,7 +5,8 @@ from e4stypes.clothing_item import ClothingItem, ClothingGender, ClothingSize
 from e4stypes.electronic_item import ElectronicItem
 from e4stypes.furniture_item import FurnitureItem
 from e4stypes.sports_gear_item import SportsGearItem
-'''
+
+"""
 This is a file you can run to seed your database!
 Purpose: every time the database gets edited/refactored, the exchange4students db needs to be
          deleted, and new fake data needs to be inserted for testing so the new schema is being
@@ -19,53 +20,86 @@ How to use: There is no neeed to manually delete and insert items. Simply run th
 
 Let me know if there are any questions,
 ~Eleni :)
-'''
+"""
 
 
 def drop_db():
-    '''Drops the database'''
-    client = MongoClient('mongodb://localhost:27017/')
-    client.drop_database('exchange4students')
-    print('Database successfully dropped')
+    """Drops the database"""
+    client = MongoClient("mongodb://localhost:27017/")
+    client.drop_database("exchange4students")
+    print("Database successfully dropped")
     print("----------------------------------------------")
 
 
 def add_clothing():
-    '''Adds 5 clothing documents to the clothing collection'''
+    """Adds 5 clothing documents to the clothing collection"""
     print("Attempting to seed the clothing collection.....")
     print()
     shirt = ClothingItem(
-        'Lightly worn Hollister shirt',
-        'Really cute, lightweight, and comfortable shirt! In good condition and selling \
-            for less than the original price.', 15.00, 0.16, 'Sarah', 'shirt',
-        ClothingSize.MEDIUM, ClothingGender.FEMALE, 'olive green')
+        "Lightly worn Hollister shirt",
+        "Really cute, lightweight, and comfortable shirt! In good condition and selling \
+            for less than the original price.",
+        15.00,
+        0.16,
+        "Sarah",
+        "shirt",
+        ClothingSize.MEDIUM,
+        ClothingGender.FEMALE,
+        "olive green",
+    )
     Database.add_item(shirt)
     print("Shirt has been successfully added")
     jeans = ClothingItem(
-        'A pair of cute Levi\'s',
-        'Classic wash jeans, well taken care of. They just don\'t fit me anymore hahah!',
-        30.00, 0.20, 'Eleni', 'jeans', ClothingSize.LARGE,
-        ClothingGender.FEMALE, 'classic blue wash')
+        "A pair of cute Levi's",
+        "Classic wash jeans, well taken care of. They just don't fit me anymore hahah!",
+        30.00,
+        0.20,
+        "Eleni",
+        "jeans",
+        ClothingSize.LARGE,
+        ClothingGender.FEMALE,
+        "classic blue wash",
+    )
     Database.add_item(jeans)
     print("Jeans have been successfully added")
     blazer = ClothingItem(
-        'A professional blazer',
-        'Its interview season! You probably need something to wear, so why not this cute \
-            blazer? Don\'t worry, its in great condition!', 20.50, 0.10,
-        'Grace', 'blazer', ClothingSize.SMALL, ClothingGender.UNISEX, 'black')
+        "A professional blazer",
+        "Its interview season! You probably need something to wear, so why not this cute \
+            blazer? Don't worry, its in great condition!",
+        20.50,
+        0.10,
+        "Grace",
+        "blazer",
+        ClothingSize.SMALL,
+        ClothingGender.UNISEX,
+        "black",
+    )
     Database.add_item(blazer)
     print("Blazer has been successfully added")
-    sweater = ClothingItem('Fluffy sweater',
-                           'So snuggly and warm, my grandma knitted it', 13.00,
-                           0.13, 'Julio', 'sweater', ClothingSize.MEDIUM,
-                           ClothingGender.UNISEX, 'Orange')
+    sweater = ClothingItem(
+        "Fluffy sweater",
+        "So snuggly and warm, my grandma knitted it",
+        13.00,
+        0.13,
+        "Julio",
+        "sweater",
+        ClothingSize.MEDIUM,
+        ClothingGender.UNISEX,
+        "Orange",
+    )
     Database.add_item(sweater)
     print("Sweater has been successfully added")
     jacket = ClothingItem(
-        'Leather jacket, vintage',
-        'Really cool vintage leather jacket. A bit worn but that\'s the point',
-        150.00, 3.00, 'David', 'leather jacket', ClothingSize.LARGE,
-        ClothingGender.MALE, 'black')
+        "Leather jacket, vintage",
+        "Really cool vintage leather jacket. A bit worn but that's the point",
+        150.00,
+        3.00,
+        "David",
+        "leather jacket",
+        ClothingSize.LARGE,
+        ClothingGender.MALE,
+        "black",
+    )
     Database.add_item(jacket)
     print("Leather jacket has been successfully added")
     print()
@@ -74,37 +108,67 @@ def add_clothing():
 
 
 def add_books():
-    '''Adds 5 book documents to the book collection'''
+    """Adds 5 book documents to the book collection"""
     print("Attempting to seed the book collection.....")
     print()
-    book1 = BookItem('Harry Potter pack for sale',
-                     'All 7 books! Come and get \'em!', 50.00, 8, 'Sarah',
-                     'Harry Potter - The Collection', 3, "-")
+    book1 = BookItem(
+        "Harry Potter pack for sale",
+        "All 7 books! Come and get 'em!",
+        50.00,
+        8,
+        "Sarah",
+        "Harry Potter - The Collection",
+        3,
+        "-",
+    )
     Database.add_item(book1)
     print("book1 has been successfully added")
     book2 = BookItem(
-        'Econ textbook, never used',
-        'Idk why I bought this to begin with. Never used it.', 75.00, 4, 'Grace', \
-            "Introduction to Engineering Economics", 7, "ECON-235")
+        "Econ textbook, never used",
+        "Idk why I bought this to begin with. Never used it.",
+        75.00,
+        4,
+        "Grace",
+        "Introduction to Engineering Economics",
+        7,
+        "ECON-235",
+    )
     Database.add_item(book2)
     print("book2 has been successfully added")
     book3 = BookItem(
-        'Comp Sci book for Prof Lowe\'s class',
-        'Good condition, you\'re gonna need this for his class...', 35.00, 5.6,
-        'Eleni', 'Data Structures in Java', 12, "CS-550")
+        "Comp Sci book for Prof Lowe's class",
+        "Good condition, you're gonna need this for his class...",
+        35.00,
+        5.6,
+        "Eleni",
+        "Data Structures in Java",
+        12,
+        "CS-550",
+    )
     Database.add_item(book3)
     print("book3 has been successfully added")
     book4 = BookItem(
-        'Chemistry textbook, freshman I\'m looking at you!',
-        'For freshman year chem, selling for much cheaper than other students.',
-        30.00, 6, 'Julio', 'Introduction to Chemistry, a Hollistic Aproach', 2,
-        "CH-115")
+        "Chemistry textbook, freshman I'm looking at you!",
+        "For freshman year chem, selling for much cheaper than other students.",
+        30.00,
+        6,
+        "Julio",
+        "Introduction to Chemistry, a Hollistic Aproach",
+        2,
+        "CH-115",
+    )
     Database.add_item(book4)
     print("book4 has been successfully added")
-    book5 = BookItem('Calculus textbook',
-                     'A little worn out, but still usable.', 28.00, 16,
-                     'David', 'Calculus made Simple, a Student Friendly Guide',
-                     3, "MA-111")
+    book5 = BookItem(
+        "Calculus textbook",
+        "A little worn out, but still usable.",
+        28.00,
+        16,
+        "David",
+        "Calculus made Simple, a Student Friendly Guide",
+        3,
+        "MA-111",
+    )
     Database.add_item(book5)
     print("book5 has been successfully added")
     print()
@@ -113,33 +177,67 @@ def add_books():
 
 
 def add_electronics():
-    '''Adds 5 electronic documents to the electronic collection'''
+    """Adds 5 electronic documents to the electronic collection"""
     print("Attempting to seed the electronic collection.....")
     print()
-    ps1 = ElectronicItem('Archaic PS1, come get herrrrr',
-                         'Classic, worth a lot of moolah, don\'t miss out!',
-                         10000.00, 10, 'Sarah', 'PlayStation',
-                         'First one ever', [10, 20, 10])
+    ps1 = ElectronicItem(
+        "Archaic PS1, come get herrrrr",
+        "Classic, worth a lot of moolah, don't miss out!",
+        10000.00,
+        10,
+        "Sarah",
+        "PlayStation",
+        "First one ever",
+        [10, 20, 10],
+    )
     Database.add_item(ps1)
     print("ps1 has been successfully added")
     ps2 = ElectronicItem(
-        'Calling all vintage video game console collectors! Selling PS2!!!',
-        'An oldie but a goodie.', 50.00, 10, 'Grace', 'PlayStation', '2nd',
-        [10, 20, 10])
+        "Calling all vintage video game console collectors! Selling PS2!!!",
+        "An oldie but a goodie.",
+        50.00,
+        10,
+        "Grace",
+        "PlayStation",
+        "2nd",
+        [10, 20, 10],
+    )
     Database.add_item(ps2)
     print("ps2 have been successfully added")
-    ps3 = ElectronicItem('PS3', 'Still works like a charm!', 100.00, 10,
-                         'Eleni', 'PlayStation', '3rd', [10, 20, 10])
+    ps3 = ElectronicItem(
+        "PS3",
+        "Still works like a charm!",
+        100.00,
+        10,
+        "Eleni",
+        "PlayStation",
+        "3rd",
+        [10, 20, 10],
+    )
     Database.add_item(ps3)
     print("ps3 has been successfully added")
     ps4 = ElectronicItem(
-        'PS4', 'Selling for cheaper than you can get it at the stores!',
-        200.00, 10, 'Julio', 'PlayStation', '4th', [10, 20, 10])
+        "PS4",
+        "Selling for cheaper than you can get it at the stores!",
+        200.00,
+        10,
+        "Julio",
+        "PlayStation",
+        "4th",
+        [10, 20, 10],
+    )
     Database.add_item(ps4)
     print("ps4 has been successfully added")
-    ps5 = ElectronicItem('PS5! YES YOU READ THAT CORRECTLY!',
-                         'You know what this is bois', 100000.00, 10, 'David',
-                         'PlayStation', '5th', [10, 20, 10])
+    ps5 = ElectronicItem(
+        "PS5! YES YOU READ THAT CORRECTLY!",
+        "You know what this is bois",
+        100000.00,
+        10,
+        "David",
+        "PlayStation",
+        "5th",
+        [10, 20, 10],
+    )
     Database.add_item(ps5)
     print("ps5 has been successfully added")
     print()
@@ -148,38 +246,67 @@ def add_electronics():
 
 
 def add_sports_gear():
-    '''Adds 5 sports gear documents to the sports collection'''
+    """Adds 5 sports gear documents to the sports collection"""
     print("Attempting to seed the sports collection.....")
     print()
-    skiis = SportsGearItem('Used skiis',
-                           'In great condition, also a great price!', 40.00,
-                           1.05, 'Sarah', 'Skiis', ClothingSize.MEDIUM,
-                           ClothingGender.UNISEX)
+    skiis = SportsGearItem(
+        "Used skiis",
+        "In great condition, also a great price!",
+        40.00,
+        1.05,
+        "Sarah",
+        "Skiis",
+        ClothingSize.MEDIUM,
+        ClothingGender.UNISEX,
+    )
     Database.add_item(skiis)
     print("skiis have been successfully added")
-    helmet = SportsGearItem('Bicycle helmet',
-                            'I have a small head, like a child.', 15.00, 0.20,
-                            'Eleni', 'Helmet', ClothingSize.SMALL,
-                            ClothingGender.UNISEX)
+    helmet = SportsGearItem(
+        "Bicycle helmet",
+        "I have a small head, like a child.",
+        15.00,
+        0.20,
+        "Eleni",
+        "Helmet",
+        ClothingSize.SMALL,
+        ClothingGender.UNISEX,
+    )
     Database.add_item(helmet)
     print("helmet has been successfully added")
     snowboard = SportsGearItem(
-        'Snowboard, no longer need it',
-        'My mom bought me a new one for my birthday, so I no longer need this. Great condition.',
-        50.00, 0.10, 'Grace', 'Snowboard', ClothingSize.SMALL,
-        ClothingGender.UNISEX)
+        "Snowboard, no longer need it",
+        "My mom bought me a new one for my birthday, so I no longer need this. Great condition.",
+        50.00,
+        0.10,
+        "Grace",
+        "Snowboard",
+        ClothingSize.SMALL,
+        ClothingGender.UNISEX,
+    )
     Database.add_item(snowboard)
     print("snowboard has been successfully added")
-    tennis_racket = SportsGearItem('Tennis Racket, signed by Serena Williams',
-                                   'Its signed!!!', 1500.00, 0.67, 'Julio',
-                                   'Tennis Racket', ClothingSize.MEDIUM,
-                                   ClothingGender.UNISEX)
+    tennis_racket = SportsGearItem(
+        "Tennis Racket, signed by Serena Williams",
+        "Its signed!!!",
+        1500.00,
+        0.67,
+        "Julio",
+        "Tennis Racket",
+        ClothingSize.MEDIUM,
+        ClothingGender.UNISEX,
+    )
     Database.add_item(tennis_racket)
     print("tennis racket has been successfully added")
-    roller_skates = SportsGearItem('Roller skates, great condition',
-                                   'Super cute and sparkly!', 45.00, 2.00,
-                                   'David', 'Roller Skates',
-                                   ClothingSize.LARGE, ClothingGender.UNISEX)
+    roller_skates = SportsGearItem(
+        "Roller skates, great condition",
+        "Super cute and sparkly!",
+        45.00,
+        2.00,
+        "David",
+        "Roller Skates",
+        ClothingSize.LARGE,
+        ClothingGender.UNISEX,
+    )
     Database.add_item(roller_skates)
     print("roller skates have been successfully added")
     print()
@@ -188,34 +315,68 @@ def add_sports_gear():
 
 
 def add_furniture():
-    '''Adds 5 furniture documents to the furniture collection'''
+    """Adds 5 furniture documents to the furniture collection"""
     print("Attempting to seed the furniture collection.....")
     print()
-    couch = FurnitureItem('Comfy couch',
-                          'Well loved, but still in pretty good condition',
-                          60.00, 40, 'Sarah', 'Couch', 'beige', [50, 20, 10])
+    couch = FurnitureItem(
+        "Comfy couch",
+        "Well loved, but still in pretty good condition",
+        60.00,
+        40,
+        "Sarah",
+        "Couch",
+        "beige",
+        [50, 20, 10],
+    )
     Database.add_item(couch)
     print("couch has been successfully added")
     table = FurnitureItem(
-        'Dining room table',
-        'Wooden dining room table. Has a few scuffs, but not bad!', 30.00, 15, \
-            'Grace', 'Table', 'wood',
-        [40, 20, 40])
+        "Dining room table",
+        "Wooden dining room table. Has a few scuffs, but not bad!",
+        30.00,
+        15,
+        "Grace",
+        "Table",
+        "wood",
+        [40, 20, 40],
+    )
     Database.add_item(table)
     print("table has been successfully added")
     bed = FurnitureItem(
-        'Bed Frame', 'Just selling the bed frame, you\'ll have \
-        to get your own mattress', 55.00, 50, 'Eleni', 'Bed', 'white',
-        [10, 20, 10])
+        "Bed Frame",
+        "Just selling the bed frame, you'll have \
+        to get your own mattress",
+        55.00,
+        50,
+        "Eleni",
+        "Bed",
+        "white",
+        [10, 20, 10],
+    )
     Database.add_item(bed)
     print("bed has been successfully added")
-    desk = FurnitureItem('Ikea desk, no longer need it',
-                         'In great condition, this is truly a steal', 60.00,
-                         35, 'Julio', 'Ikea Desk', 'navy', [20, 20, 30])
+    desk = FurnitureItem(
+        "Ikea desk, no longer need it",
+        "In great condition, this is truly a steal",
+        60.00,
+        35,
+        "Julio",
+        "Ikea Desk",
+        "navy",
+        [20, 20, 30],
+    )
     Database.add_item(desk)
     print("desk has been successfully added")
-    shelf = FurnitureItem('Book shelf, never used', 'Brand new', 110.00, 25,
-                          'David', 'Book Shelf', 'black', [10, 20, 100])
+    shelf = FurnitureItem(
+        "Book shelf, never used",
+        "Brand new",
+        110.00,
+        25,
+        "David",
+        "Book Shelf",
+        "black",
+        [10, 20, 100],
+    )
     Database.add_item(shelf)
     print("shelf has been successfully added")
     print()


### PR DESCRIPTION
I've been having trouble running `yapf` lately (its been stalling when trying to run it recursively). Because of the method we are using to check formatting in the CI, this may cause problems in the future. I think we should change formatters from `yapf` to `black`, another popular alternative I've found. Also, I think we'll like the look of `black`'s formatting better.

To run black on the project, do `python3 -m black .` from the root directory of the project.
